### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS=-I m4
 
 #Script files
 bin_SCRIPTS = src/sonic_logging_cli

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_PREREQ([2.69])
 AC_INIT([sonic-logging],[1.0.1],[sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([src])
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CHECK_HEADERS([libxml/parser.h])
 
 # Checks for programs.


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.